### PR TITLE
Update _gallery.scss

### DIFF
--- a/src/sass/layout/_gallery.scss
+++ b/src/sass/layout/_gallery.scss
@@ -62,7 +62,7 @@
 .gallary__img-mob-dog,
 .gallary__img-mob-drink,
 .gallary__img-mob-weirddessert {
-  transition-property: transform;
+  transition-property: transform, z-index;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;
   z-index: 1;


### PR DESCRIPTION
Вчора помилково забрав z-index в transition, повернув назад, зараз картинки не мають ховатись одна за одну при ховері